### PR TITLE
Get user id instead of forum id

### DIFF
--- a/inc/plugins/lightavatars.php
+++ b/inc/plugins/lightavatars.php
@@ -207,7 +207,7 @@ function lightavatars_activate() {
         "forumdisplay_announcements_announcement" => [
             'forumdisplay_announcements_announcement', 
             '#<(.*?)'.preg_quote('{$announcement[\'subject\']}').'#',
-            '<!--{+}forumdisplay_announcements_announcement|{$announcement[\'fid\']}{-}--><\\1{$announcement[\'subject\']}'
+            '<!--{+}forumdisplay_announcements_announcement|{$announcement[\'uid\']}{-}--><\\1{$announcement[\'subject\']}'
         ]
     ];
     


### PR DESCRIPTION
User's avatar in the announcements will be displayed properly. Also, clicking on the avatar will redirect us properly to the user's profile.